### PR TITLE
Fixing hoisting error on auth changes

### DIFF
--- a/lib/features/auth/application/auth_controller.dart
+++ b/lib/features/auth/application/auth_controller.dart
@@ -23,7 +23,7 @@ class AuthController extends _$AuthController {
     /// listen to auth changes
     repository.authStateChange((user) {
       state = AsyncData(user);
-      _updateAuthState(userEntity);
+      _updateAuthState(user);
     });
     return userEntity;
     // TODO(vh): how to cancel subscription override dispose


### PR DESCRIPTION
The userEntity is used on the build process and hoisted inside the updateAuth method making the boolean isUserAuth always false.